### PR TITLE
Change save behavior

### DIFF
--- a/EntityFramework.Implementation/DbContextScope.cs
+++ b/EntityFramework.Implementation/DbContextScope.cs
@@ -82,9 +82,12 @@ namespace Numero3.EntityFramework.Implementation
             {
                 c = CommitInternal();
             }
+            else
+            {
+                c = SaveInternal();
+            }
 
             _completed = true;
-
             return c;
         }
 
@@ -109,6 +112,10 @@ namespace Numero3.EntityFramework.Implementation
             {
                 c = await CommitInternalAsync(cancelToken).ConfigureAwait(false);
             }
+            else
+            {
+                c = await SaveInternalAsync(cancelToken).ConfigureAwait(false);
+            }
 
             _completed = true;
             return c;
@@ -122,6 +129,16 @@ namespace Numero3.EntityFramework.Implementation
         private Task<int> CommitInternalAsync(CancellationToken cancelToken)
         {
             return _dbContexts.CommitAsync(cancelToken);
+        }
+
+        private int SaveInternal()
+        {
+            return _dbContexts.Save();
+        }
+
+        private Task<int> SaveInternalAsync(CancellationToken cancelToken)
+        {
+            return _dbContexts.SaveAsync(cancelToken);
         }
 
         private void RollbackInternal()

--- a/EntityFramework.Implementation/EntityFramework.Implementation.csproj
+++ b/EntityFramework.Implementation/EntityFramework.Implementation.csproj
@@ -61,6 +61,7 @@
       <Link>DbContextScope.Interfaces.licenseheader</Link>
     </None>
     <None Include="App.config" />
+    <None Include="EntityFramework.Implementation.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/EntityFramework.Implementation/EntityFramework.Implementation.nuspec
+++ b/EntityFramework.Implementation/EntityFramework.Implementation.nuspec
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$title$</title>
+    <authors>$author$</authors>
+    <owners>$author$</owners>
+    <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
+    <projectUrl>https://github.com/Symphono/DbContextScope</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>$description$</description>
+    <copyright>Copyright 2015</copyright>
+  </metadata>
+</package>

--- a/EntityFramework.Implementation/Properties/AssemblyInfo.cs
+++ b/EntityFramework.Implementation/Properties/AssemblyInfo.cs
@@ -13,9 +13,9 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("EntityFramework.Implementation")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("DbContextScope was created out of the need for a better way to manage DbContext instances in Entity Framework-based applications.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("mehdime")]
 [assembly: AssemblyProduct("EntityFramework.Implementation")]
 [assembly: AssemblyCopyright("Copyright ©  2014")]
 [assembly: AssemblyTrademark("")]
@@ -39,5 +39,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]

--- a/EntityFramework.Interfaces/Properties/AssemblyInfo.cs
+++ b/EntityFramework.Interfaces/Properties/AssemblyInfo.cs
@@ -39,5 +39,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]


### PR DESCRIPTION
Implicitly create a transaction with every `DbContextScope`, and make `SaveChanges` occur synchronously. `SaveChanges` on the outermost scope causes the transaction to be committed.
